### PR TITLE
ci: support ci for forked pull requests

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -1,0 +1,23 @@
+{
+  "jobs": [
+    {
+      "enabled": true,
+      "pipeline_slug": "tk-btf-pull-request-pipeline",
+      "allow_org_users": true,
+      "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": ["github-actions[bot]"],
+      "set_commit_status": true,
+      "commit_status_context": "tk-btf-ci",
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "skip_ci_labels": [ ],
+      "skip_target_branches": [ ],
+      "skip_ci_on_only_changed": [
+        "\\.md$"
+      ],
+      "always_require_ci_on_changed": [ ]
+    }
+  ]
+}

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -10,8 +10,8 @@
       "commit_status_context": "tk-btf-ci",
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
-      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "trigger_comment_regex": "^test",
+      "always_trigger_comment_regex": "^test",
       "skip_ci_labels": [ ],
       "skip_target_branches": [ ],
       "skip_ci_on_only_changed": [

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,9 +18,24 @@ spec:
     kind: Pipeline
     metadata:
       name: tk-btf
+      description: ':go: Build and test tk-btf'
     spec:
       repository: elastic/tk-btf
       pipeline_file: ".buildkite/pipeline.yml"
+      maximum_timeout_in_minutes: 120
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        build_tags: true
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:
         sec-linux-platform:
           access_level: MANAGE_BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -27,6 +27,7 @@ spec:
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
+        build_branches: true
         filter_enabled: true
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)


### PR DESCRIPTION
This PR sets up the ci-agent properly to support running the CI tests for forked PRs