### PR TITLE
Expose AnyTypesByName from `Spec` Object 

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 tk-btf
-Copyright 2023-2024 Elasticsearch BV
+Copyright 2023-2025 Elasticsearch BV
 
 ================================================================================
 Third party libraries used by tk-btf:

--- a/spec.go
+++ b/spec.go
@@ -198,6 +198,11 @@ func (s *Spec) ContainsSymbol(symbolName string) bool {
 	return s.spec.TypeByName(symbolName, &funcType) == nil
 }
 
+// AnyTypesByName returns a btf Type interface for the given name. This can then be cast to a more specific btf type.
+func (s *Spec) AnyTypesByName(name string) ([]btf.Type, error) {
+	return s.spec.AnyTypesByName(name)
+}
+
 func (b *btfSpecWrapper) AnyTypesByName(name string) ([]btf.Type, error) {
 	return b.spec.AnyTypesByName(name)
 }

--- a/spec.go
+++ b/spec.go
@@ -198,7 +198,10 @@ func (s *Spec) ContainsSymbol(symbolName string) bool {
 	return s.spec.TypeByName(symbolName, &funcType) == nil
 }
 
-// AnyTypesByName returns a btf Type interface for the given name. This can then be cast to a more specific btf type.
+// AnyTypesByName returns all [btf.Type] interfaces that match the given name.
+// It returns a slice since multiple distinct types can share the same name in BTF.
+// Each element of the slice can then be type-asserted to a more specific type,
+// such as a [*btf.Struct] or [*btf.Enum].
 func (s *Spec) AnyTypesByName(name string) ([]btf.Type, error) {
 	return s.spec.AnyTypesByName(name)
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -152,7 +152,7 @@ func TestSpec_GetType(t *testing.T) {
 		regs: nil,
 	}
 
-	foundType, err := mockSpec.AnyTypesByName("dentry")
+	foundTypes, err := mockSpec.AnyTypesByName("dentry")
 	require.NoError(t, err)
-	require.NotNil(t, foundType)
+	require.Len(t, foundTypes, 1)
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -143,3 +143,16 @@ func TestSpec_ContainsSymbol(t *testing.T) {
 	require.False(t, mockSpec.ContainsSymbol("unknown"))
 	require.True(t, mockSpec.ContainsSymbol("dentry"))
 }
+
+func TestSpec_GetType(t *testing.T) {
+	mockSpec := &Spec{
+		spec: newMockedBTFSpecWithTypesMap(map[string]btf.Type{
+			"dentry": &btf.Func{},
+		}),
+		regs: nil,
+	}
+
+	foundType, err := mockSpec.AnyTypesByName("dentry")
+	require.NoError(t, err)
+	require.NotNil(t, foundType)
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -144,7 +144,7 @@ func TestSpec_ContainsSymbol(t *testing.T) {
 	require.True(t, mockSpec.ContainsSymbol("dentry"))
 }
 
-func TestSpec_GetType(t *testing.T) {
+func TestSpec_AnyTypesByName(t *testing.T) {
 	mockSpec := &Spec{
 		spec: newMockedBTFSpecWithTypesMap(map[string]btf.Type{
 			"dentry": &btf.Func{},


### PR DESCRIPTION
There's [currently a bug](https://github.com/elastic/beats/issues/45897) in beats that stems from the fact that the fnotify probes are hard-coding enum values when constructing probe filters:
```
		f.pathProbeFilter = "(mc==1 || md==1 || ma==1 || mm==1 || mmt==1 || mmf==1) && dt==2"
		f.inodeProbeFilter = "(mc==1 || md==1 || ma==1 || mm==1 || mmt==1 || mmf==1) && dt==3 && nptr!=0"
		f.dentryProbeFilter = "(mc==1 || md==1 || ma==1 || mm==1 || mmt==1 || mmf==1) && dt==4"
```

This exposes the underlying Cilium `AnyTypesByName` function so we can fetch the actual enum values from the BTF. I don't see this exposed by `tk-btf` anywhere else, and I figured this is more efficient than having auditbeat's FIM code call `LoadKernelSpec()` twice. If there's a better way to do this, just tell me. 